### PR TITLE
Format longer mappings correctly

### DIFF
--- a/plugin/follow-my-lead.vim
+++ b/plugin/follow-my-lead.vim
@@ -78,8 +78,17 @@ function! FMLAddDescription(src, mappings)
 endfunction
 
 function! FMLFormatMappings(source, mappings)
-  let formatted = map(a:mappings, 'printf("    %1s | %-5s | %s", v:val.mode, v:val.lhs, get(v:val, "desc", v:val.rhs))')
+  let mapping_width = FMLCalcMappingWidth(a:mappings)
+  let formatted = map(a:mappings, 'printf("    %1s | %-' . mapping_width . 's | %s", v:val.mode, v:val.lhs, get(v:val, "desc", v:val.rhs))')
   return a:source. "\n" . repeat('-', strchars(a:source)) . "\n\n" . join(formatted, "\n")
+endfunction
+
+function! FMLCalcMappingWidth(mappings)
+  let mapping_width = 1
+  for val in a:mappings
+    let mapping_width = max([mapping_width, strlen(val.lhs)])
+  endfor
+  return mapping_width
 endfunction
 
 function! FMLClose()


### PR DESCRIPTION
This makes things work for mappings with more chars in them.  I have some mappings with `<space>` which was breaking the table format.
