### PR TITLE
Fix for descriptions before noremap mappings

### DIFF
--- a/plugin/follow-my-lead.vim
+++ b/plugin/follow-my-lead.vim
@@ -65,7 +65,7 @@ function! FMLAddDescription(src, mappings)
   let lines_with_index = map(deepcopy(src_lines), '[v:key, v:val]') 
   let comments_by_id = {}
   for [idx, line] in lines_with_index
-    let lhs = matchlist(line, '\c\m^\(\a*\)map.*<leader>\(\S\+\)')
+    let lhs = matchlist(line, '\c\m^\(\a\?\)\a*map.*<leader>\(\S\+\)')
     if(!empty(lhs))
       let prev_line = src_lines[idx - 1]
       let comment = matchlist(prev_line, '^"\s*\(.*\)')


### PR DESCRIPTION
Fix for descriptions before noremap mappings

Before it would set the key incorrectly for comments_by_id if you had a noremap mapping.  For example nnoremap <Leader>a would have the key "nnore_a".  This would cause the descriptions not to be listed in the table.
